### PR TITLE
Fix Windows build: Remove VSG_DECLSPEC from template classes

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,10 @@ source:
     sha256: bd9c58f615d44a4de684fc0c97acc010a548a6714a64c98c59ee2b86f3e66e3d
     patches:
       - patches/ignore-vulkan-version.patch
+      - patches/remove-vsg-declspec-from-templates.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('vulkanscenegraph', max_pin='x.x') }}
 

--- a/recipe/patches/ignore-vulkan-version.patch
+++ b/recipe/patches/ignore-vulkan-version.patch
@@ -4,7 +4,7 @@ index a75f15d8..6a7a0c91 100644
 +++ b/CMakeLists.txt
 @@ -7,7 +7,7 @@ project(vsg
  )
- set(VSG_SOVERSION 14)
+ set(VSG_SOVERSION 15)
  SET(VSG_RELEASE_CANDIDATE 0)
 -set(Vulkan_MIN_VERSION 1.1.70.0)
 +set(Vulkan_MIN_VERSION )

--- a/recipe/patches/remove-vsg-declspec-from-templates.patch
+++ b/recipe/patches/remove-vsg-declspec-from-templates.patch
@@ -1,0 +1,48 @@
+diff -urN a/include/vsg/core/Array2D.h b/include/vsg/core/Array2D.h
+--- a/include/vsg/core/Array2D.h	2025-11-28 02:32:18.000000000 -0800
++++ b/include/vsg/core/Array2D.h	2025-11-28 10:14:39.308610914 -0800
+@@ -30,7 +30,7 @@
+ {
+ 
+     template<typename T>
+-    class VSG_DECLSPEC Array2D : public Data
++    class Array2D : public Data
+     {
+     public:
+         using value_type = T;
+diff -urN a/include/vsg/core/Array3D.h b/include/vsg/core/Array3D.h
+--- a/include/vsg/core/Array3D.h	2025-11-28 02:32:18.000000000 -0800
++++ b/include/vsg/core/Array3D.h	2025-11-28 10:14:39.310247403 -0800
+@@ -30,7 +30,7 @@
+ namespace vsg
+ {
+     template<typename T>
+-    class VSG_DECLSPEC Array3D : public Data
++    class Array3D : public Data
+     {
+     public:
+         using value_type = T;
+diff -urN a/include/vsg/core/Array.h b/include/vsg/core/Array.h
+--- a/include/vsg/core/Array.h	2025-11-28 02:32:18.000000000 -0800
++++ b/include/vsg/core/Array.h	2025-11-28 10:14:39.307061344 -0800
+@@ -32,7 +32,7 @@
+ namespace vsg
+ {
+     template<typename T>
+-    class VSG_DECLSPEC Array : public Data
++    class Array : public Data
+     {
+     public:
+         using value_type = T;
+diff -urN a/include/vsg/core/Value.h b/include/vsg/core/Value.h
+--- a/include/vsg/core/Value.h	2025-11-28 02:32:18.000000000 -0800
++++ b/include/vsg/core/Value.h	2025-11-28 10:14:39.311706471 -0800
+@@ -36,7 +36,7 @@
+ namespace vsg
+ {
+     template<typename T>
+-    class VSG_DECLSPEC Value : public Data
++    class Value : public Data
+     {
+     public:
+         using value_type = T;


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
