### PR TITLE
Run VulkanSceneGraph CMake consumer test

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -18,3 +22,6 @@ spirv_tools:
 - '2026'
 target_platform:
 - linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -18,3 +22,6 @@ spirv_tools:
 - '2026'
 target_platform:
 - linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,3 +1,7 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -18,3 +22,6 @@ spirv_tools:
 - '2026'
 target_platform:
 - linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -2,6 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -20,3 +24,6 @@ spirv_tools:
 - '2026'
 target_platform:
 - osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -2,6 +2,10 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -20,3 +24,6 @@ spirv_tools:
 - '2026'
 target_platform:
 - osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,3 +1,5 @@
+c_compiler:
+- vs2022
 c_stdlib:
 - vs
 channel_sources:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,6 +45,14 @@ test:
     - if not exist %PREFIX%\\Library\\lib\\vsg.lib exit 1  # [win]
     - if not exist %PREFIX%\\Library\\bin\\vsg-*.dll exit 1  # [win]
     - if not exist %PREFIX%\\Library\\lib\\cmake\\vsg\\vsgConfig.cmake exit 1  # [win]
+  requires:
+    - {{ compiler("c") }}
+    - {{ compiler("cxx") }}
+    - cmake
+    - ninja  # [not win]
+    - pkgconfig  # [linux]
+  files:
+    - tests/
   downstreams:
     - osg2vsg
     - vsgqt

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -1,0 +1,13 @@
+@echo on
+
+cmake tests ^
+  %CMAKE_ARGS% ^
+  -B tests/build ^
+  -DBUILD_SHARED_LIBS=ON
+if errorlevel 1 exit 1
+
+cmake --build tests/build --parallel --config Release
+if errorlevel 1 exit 1
+
+ctest --test-dir tests/build --output-on-failure -C Release
+if errorlevel 1 exit 1

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -exo pipefail
+
+cmake tests \
+    ${CMAKE_ARGS} \
+    -G Ninja \
+    -B tests/build \
+    -DBUILD_SHARED_LIBS=ON \
+    -DCMAKE_BUILD_TYPE=Release
+
+cmake --build tests/build --parallel
+export LD_LIBRARY_PATH="${PREFIX}/lib:${LD_LIBRARY_PATH:-}"
+export DYLD_FALLBACK_LIBRARY_PATH="${PREFIX}/lib:${DYLD_FALLBACK_LIBRARY_PATH:-}"
+ctest --test-dir tests/build --output-on-failure

--- a/recipe/tests/CMakeLists.txt
+++ b/recipe/tests/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.7)
+
+project(vsg_consumer)
+
+include(CTest)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+find_package(vsg CONFIG REQUIRED)
+
+add_executable(vsg_consumer main.cpp)
+target_link_libraries(vsg_consumer PRIVATE vsg::vsg)
+add_test(NAME vsg_consumer COMMAND vsg_consumer)

--- a/recipe/tests/main.cpp
+++ b/recipe/tests/main.cpp
@@ -1,0 +1,8 @@
+#include <vsg/all.h>
+
+int main()
+{
+    auto group = vsg::Group::create();
+    group->children.push_back(vsg::Group::create());
+    return group->children.size() == 1 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- Add a downstream CMake/CTest package test using `find_package(vsg CONFIG REQUIRED)` and the exported `vsg::vsg` target.
- Keep the test headless by constructing a small `vsg::Group`, so it validates the installed ABI/exported target without requiring a Vulkan device.
- Rerender with conda-smithy so the added test compiler/CMake requirements are represented in CI metadata.

## Validation
- `git diff --check upstream/main..HEAD`
- `conda-smithy recipe-lint --conda-forge recipe`